### PR TITLE
Disable schedule in cleanup-repository.yaml

### DIFF
--- a/.github/workflows/cleanup-repository.yaml
+++ b/.github/workflows/cleanup-repository.yaml
@@ -1,7 +1,7 @@
 name: Remove old artifacts
 on:
-  schedule:
-    - cron: '0 12 * * *' # every day at 12:00 UTC
+  # schedule:
+  #   - cron: '0 12 * * *' # every day at 12:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Scope

Implemented:
- Since we have not build a package yet, the pipeline failing, so I'm disabling the schedule trigger until the stream actually implemented.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
