### PR TITLE
Update cleanup-repository.yaml

### DIFF
--- a/.github/workflows/cleanup-repository.yaml
+++ b/.github/workflows/cleanup-repository.yaml
@@ -1,7 +1,7 @@
 name: Remove old artifacts
 on:
-  # schedule:
-  #   - cron: '0 12 * * *' # every day at 12:00 UTC
+  schedule:
+    - cron: '0 12 * * *' # every day at 12:00 UTC
   workflow_dispatch:
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
           package-type: container
           token: ${{ secrets.GITHUB_TOKEN }}
           min-versions-to-keep: 10
-          delete-only-pre-release-versions: "true"
+          ignore-versions: v([0-9]+\.?)+$
 
       - name: Delete old package versions of helm/${{ github.repository }}
         uses: actions/delete-package-versions@v5.0.0
@@ -32,4 +32,4 @@ jobs:
           package-type: container
           token: ${{ secrets.GITHUB_TOKEN }}
           min-versions-to-keep: 10
-          delete-only-pre-release-versions: "true"
+          ignore-versions: v([0-9]+\.?)+$


### PR DESCRIPTION
It seems that the workflow that delete old versions of the Arcane plugin deleted release version. This PR should fix this behavior by replacing the delete-only-pre-release-versions option with ignore-versions.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
