### PR TITLE
Update change capture interval boundaries

### DIFF
--- a/.helm/templates/crd-cdm.yaml
+++ b/.helm/templates/crd-cdm.yaml
@@ -85,9 +85,9 @@ spec:
                   description: Name of a CDM entity to stream.
                 changeCaptureIntervalSeconds:
                   type: integer
-                  description: How long to wait before polling for next result set. Can be from 1 to 60 seconds.
+                  description: How long to wait before polling for next result set. Can be from 1 to 1 hour.
                   minimum: 1
-                  maximum: 60
+                  maximum: 3600
                 rowsPerGroup:
                   type: integer
                   description: Number of rows per parquet rowgroup.


### PR DESCRIPTION
Update changeCaptureIntevalSeconds to be able to use 90 seconds interval in production infrastructure/

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
